### PR TITLE
Refactor get and getArray for parts

### DIFF
--- a/src/musx/dom/BaseClasses.h
+++ b/src/musx/dom/BaseClasses.h
@@ -76,7 +76,8 @@ using NoteNumber = int16_t;         ///< Note identifier.
 using LayerIndex = unsigned int;    ///< Layer index (valid values are 0..3)
 
 constexpr Cmper MUSX_GLOBALS_CMPER = 65534; ///< The prefs cmper for global variables (used sparingly since Finale 26.2)
-constexpr int MAX_LAYERS = 4;   ///< The maximum number of music layers in a Finale document.
+constexpr int MAX_LAYERS = 4;       ///< The maximum number of music layers in a Finale document.
+constexpr Cmper SCORE_PARTID = 0;   ///< The part id of the score.
 
 class Document;
 /** @brief Shared `Document` pointer */

--- a/src/musx/dom/BaseClasses.h
+++ b/src/musx/dom/BaseClasses.h
@@ -198,8 +198,8 @@ protected:
      * @brief Constructs the OptionsBase and validates XmlNodeName in the derived class.
      *
      * @param document A weak pointer to the parent document
-     * @param partId Usually 0. This parameter is needed for the generic factory routine.
-     * @param shareMode Usually `ShareMode::All`. This parameter is needed for the generic factory routine.
+     * @param partId Always 0. This parameter is needed for the generic factory routine.
+     * @param shareMode Always `ShareMode::All`. This parameter is needed for the generic factory routine.
      */
     OptionsBase(const DocumentWeakPtr& document, Cmper partId, ShareMode shareMode)
         : Base(document, partId, shareMode) {}
@@ -273,7 +273,7 @@ protected:
      * @brief Constructs a DetailsBase object.
      * 
      * @param document A weak pointer to the parent document
-     * @param partId The part Id for this Other, or zero if for score.
+     * @param partId The part Id for this Detail, or zero if for score.
      * @param shareMode Usually `ShareMode::All`. This parameter is used with linked parts data.
      * @param cmper1 The first `Cmper` key value.
      * @param cmper2 The second `Cmper` key value.
@@ -388,7 +388,7 @@ public:
      * @param document A weak pointer to the document object.
      */
     explicit FontInfo(const DocumentWeakPtr& document)
-        : Base(document, 0, ShareMode::All) {}
+        : Base(document, SCORE_PARTID, ShareMode::All) {}
 
     /**
      * @brief Get the name of the font.
@@ -501,11 +501,11 @@ public:
     /**
      * @brief Constructs a MusicRange object.
      * @param document Shared pointer to the document.
-     * @param partId The part ID if this range is unlinked.
+     * @param partId The part ID if this range is unlinked, otherwise 0.
      * @param shareMode The share mode if this range is unlinked.
      * @param cmper Comperator parameter. This value is zero for ranges taken from @ref others::InstrumentUsed.
      */
-    explicit MusicRange(const DocumentWeakPtr& document, Cmper partId = 0, ShareMode shareMode = ShareMode::All, Cmper cmper = 0)
+    explicit MusicRange(const DocumentWeakPtr& document, Cmper partId = SCORE_PARTID, ShareMode shareMode = ShareMode::All, Cmper cmper = 0)
         : OthersBase(document, partId, shareMode, cmper) {}
 
     MeasCmper startMeas{};      ///< Starting measure in the range.
@@ -534,7 +534,7 @@ public:
      * @param shareMode The share mode if this name positioning is unlinked.
      * @param cmper Comperator parameter. This value is zero for name positioning taken from @ref options::StaffOptions.
      */
-    explicit NamePositioning(const DocumentWeakPtr& document, Cmper partId = 0, ShareMode shareMode = ShareMode::All, Cmper cmper = 0)
+    explicit NamePositioning(const DocumentWeakPtr& document, Cmper partId = SCORE_PARTID, ShareMode shareMode = ShareMode::All, Cmper cmper = 0)
         : OthersBase(document, partId, shareMode, cmper) {}
 
     /// @brief Alignment and justification options for staff and group names.

--- a/src/musx/dom/Implementations.cpp
+++ b/src/musx/dom/Implementations.cpp
@@ -120,7 +120,7 @@ std::shared_ptr<FontInfo> options::FontOptions::getFontInfo(const DocumentPtr& d
 
 std::string FontInfo::getName() const
 {
-    auto fontDef = getDocument()->getOthers()->get<others::FontDefinition>(fontId);
+    auto fontDef = getDocument()->getOthers()->get<others::FontDefinition>(getPartId(), fontId);
     if (fontDef) {
         return fontDef->name;
     }
@@ -129,7 +129,7 @@ std::string FontInfo::getName() const
 
 void FontInfo::setFontIdByName(const std::string& name)
 {
-    auto fontDefs = getDocument()->getOthers()->getArray<others::FontDefinition>();
+    auto fontDefs = getDocument()->getOthers()->getArray<others::FontDefinition>(getPartId());
     for (auto fontDef : fontDefs) {
         if (fontDef->name == name) {
             fontId = fontDef->getCmper();
@@ -252,7 +252,7 @@ bool details::GFrameHold::iterateEntries(LayerIndex layerIndex, std::function<bo
         throw std::invalid_argument("invalid layer index [" + std::to_string(layerIndex) + "]");
     }
     if (!frames[layerIndex]) return true; // nothing here
-    auto frame = getDocument()->getOthers()->get<others::Frame>(frames[layerIndex]);
+    auto frame = getDocument()->getOthers()->get<others::Frame>(getPartId(), frames[layerIndex]);
     if (frame) {
         auto firstEntry = getDocument()->getEntries()->get<Entry>(frame->startEntry);
         if (!firstEntry) {
@@ -292,7 +292,7 @@ std::shared_ptr<others::Staff> others::InstrumentUsed::getStaffAtIndex(const std
 {
     if (index > iuArray.size()) return nullptr;
     auto iuItem = iuArray[index];
-    return iuItem->getDocument()->getOthers()->getEffectiveForPart<others::Staff>(iuItem->getPartId(), iuItem->staffId);
+    return iuItem->getDocument()->getOthers()->get<others::Staff>(iuItem->getPartId(), iuItem->staffId);
 }
 
 // ****************************
@@ -301,7 +301,7 @@ std::shared_ptr<others::Staff> others::InstrumentUsed::getStaffAtIndex(const std
 
 std::string others::MarkingCategory::getName() const
 {
-    auto catName = getDocument()->getOthers()->get<others::MarkingCategoryName>(getCmper());
+    auto catName = getDocument()->getOthers()->get<others::MarkingCategoryName>(getPartId(), getCmper());
     if (catName) {
         return catName->name;
     }
@@ -386,7 +386,7 @@ std::string others::TextBlock::getText(bool trimTags) const
 
 std::string others::TextBlock::getText(const DocumentPtr& document, const Cmper textId, bool trimTags)
 {
-    auto textBlock = document->getOthers()->get<others::TextBlock>(textId);
+    auto textBlock = document->getOthers()->get<others::TextBlock>(SCORE_PARTID, textId);
     if (textBlock) {
         return textBlock->getText(trimTags);
     }
@@ -400,7 +400,7 @@ std::string others::TextBlock::getText(const DocumentPtr& document, const Cmper 
 std::shared_ptr<others::Enclosure> others::TextExpressionDef::getEnclosure() const
 {
     if (!hasEnclosure) return nullptr;
-    return getDocument()->getOthers()->get<others::TextExpressionEnclosure>(getCmper());
+    return getDocument()->getOthers()->get<others::TextExpressionEnclosure>(getPartId(), getCmper());
 }
 
 } // namespace dom    

--- a/src/musx/dom/ObjectPool.h
+++ b/src/musx/dom/ObjectPool.h
@@ -177,12 +177,12 @@ public:
         if (auto partVersion = get<T>(key)) {
             return partVersion;
         }
-        if (key.partId == 0) {
+        if (key.partId == SCORE_PARTID) {
             // if this is already the score version, there is nothing to return.
             return nullptr;
         }
         ObjectKey scoreKey(key);
-        scoreKey.partId = 0;
+        scoreKey.partId = SCORE_PARTID;
         return get<T>(scoreKey);
     }
 

--- a/src/musx/factory/FieldPopulatorsOthers.h
+++ b/src/musx/factory/FieldPopulatorsOthers.h
@@ -61,7 +61,7 @@ struct FieldPopulator<TextRepeatEnclosure> : private FieldPopulator<Enclosure>
 
 MUSX_RESOLVER_ARRAY(LayerAttributes, {
     [](const dom::DocumentPtr& document) {
-        auto layers = document->getOthers()->getArray<LayerAttributes>();
+        auto layers = document->getOthers()->getArray<LayerAttributes>(SCORE_PARTID);
         if (layers.size() != 4) {
             throw std::invalid_argument("Expected exactly 4 <layerAtts> elements.");
         }
@@ -75,7 +75,7 @@ MUSX_RESOLVER_ARRAY(LayerAttributes, {
 
 MUSX_RESOLVER_ARRAY(MarkingCategory, {
     [](const dom::DocumentPtr& document) {
-        auto cats = document->getOthers()->getArray<MarkingCategory>();
+        auto cats = document->getOthers()->getArray<MarkingCategory>(SCORE_PARTID);
         for (const auto& cat : cats) {
             if (cat->categoryType == MarkingCategory::CategoryType::Invalid) {
                 throw std::invalid_argument("Encountered <markingsCategory> node (cmper " + std::to_string(cat->getCmper()) + ") with no categoryType");
@@ -86,10 +86,10 @@ MUSX_RESOLVER_ARRAY(MarkingCategory, {
 
 MUSX_RESOLVER_ARRAY(TextExpressionDef, {
     [](const dom::DocumentPtr& document) {
-        auto exps = document->getOthers()->getArray<TextExpressionDef>();
+        auto exps = document->getOthers()->getArray<TextExpressionDef>(SCORE_PARTID);
         for (const auto& instance : exps) {
             if (instance->categoryId) {
-                auto markingCat = document->getOthers()->get<MarkingCategory>(instance->categoryId);
+                auto markingCat = document->getOthers()->get<MarkingCategory>(instance->getPartId(), instance->categoryId);
                 if (!markingCat) {
                     throw std::invalid_argument("Marking category for text expression " + std::to_string(instance->getCmper()) + " does not exist.");
                 }

--- a/src/musx/factory/PoolFactory.h
+++ b/src/musx/factory/PoolFactory.h
@@ -107,7 +107,7 @@ public:
  * represent various document options stored in a `ScalarPool`. It includes functionality 
  * for extracting and creating these objects from XML elements.
  */
-class OptionsFactory : public PoolFactory<OptionsFactory, dom::OptionsBase, dom::ScalarPool<dom::OptionsBase>>
+class OptionsFactory : public PoolFactory<OptionsFactory, dom::OptionsBase, dom::OptionsPool>
 {
 public:
     using PoolFactory::create;

--- a/src/musx/factory/TypeRegistry.h
+++ b/src/musx/factory/TypeRegistry.h
@@ -124,7 +124,13 @@ public:
                             for (auto child = node->getFirstChildElement(); child; child = child->getNextSibling()) {
                                 instance->addUnlinkedNode(child->getTagName());
                             }
-                            auto scoreValue = pool->template get<T>(std::forward<Args>(args)...);
+                            auto scoreValue = [&]() {
+                                if constexpr (std::is_same_v<PoolPtr, OthersPoolPtr> || std::is_same_v<PoolPtr, DetailsPoolPtr>) {
+                                    return pool->template get<T>(partId, std::forward<Args>(args)...);
+                                } else {
+                                    return pool->template get<T>(std::forward<Args>(args)...);
+                                }
+                            }();
                             if (scoreValue) {
                                 *instance = *scoreValue;
                             }

--- a/tests/details/gfhold.cpp
+++ b/tests/details/gfhold.cpp
@@ -63,7 +63,7 @@ TEST(GFrameHoldTest, PopulateFields)
 
     // Test GFrameHold for cmper1=3, cmper2=915
     {
-        auto gfhold = details->get<details::GFrameHold>(3, 915);
+        auto gfhold = details->get<details::GFrameHold>(SCORE_PARTID, 3, 915);
         ASSERT_TRUE(gfhold);
 
         EXPECT_EQ(gfhold->clefId.value_or(-1), 0); // Default to -1 if not set
@@ -79,7 +79,7 @@ TEST(GFrameHoldTest, PopulateFields)
 
     // Test GFrameHold for cmper1=3, cmper2=1083
     {
-        auto gfhold = details->get<details::GFrameHold>(3, 1083);
+        auto gfhold = details->get<details::GFrameHold>(SCORE_PARTID, 3, 1083);
         ASSERT_TRUE(gfhold);
 
         EXPECT_EQ(gfhold->clefId.value_or(-1), 3); // Default to -1 if not set
@@ -95,7 +95,7 @@ TEST(GFrameHoldTest, PopulateFields)
 
     // Test GFrameHold for cmper1=3, cmper2=1129
     {
-        auto gfhold = details->get<details::GFrameHold>(3, 1129);
+        auto gfhold = details->get<details::GFrameHold>(SCORE_PARTID, 3, 1129);
         ASSERT_TRUE(gfhold);
 
         EXPECT_FALSE(gfhold->clefId.has_value());
@@ -176,7 +176,7 @@ constexpr static musxtest::string_view xmlNoClefs = R"xml(
     auto details = doc->getDetails();
     ASSERT_TRUE(details);
 
-    auto gfhold = details->get<details::GFrameHold>(3, 915);
+    auto gfhold = details->get<details::GFrameHold>(SCORE_PARTID, 3, 915);
     ASSERT_TRUE(gfhold);
 
     EXPECT_THROW(

--- a/tests/others/enclosure.cpp
+++ b/tests/others/enclosure.cpp
@@ -24,6 +24,7 @@
 #include "musx/musx.h"
 #include "test_utils.h"
 
+using namespace musx::dom;
 
 TEST(EnclosureTest, TextExpressionEnclosure)
 {
@@ -51,16 +52,16 @@ TEST(EnclosureTest, TextExpressionEnclosure)
         auto doc = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(xml);
         auto others = doc->getOthers();
         ASSERT_TRUE(others);
-        auto enclosure = others->get<musx::dom::others::TextExpressionEnclosure>(1);
+        auto enclosure = others->get<others::TextExpressionEnclosure>(SCORE_PARTID, 1);
         EXPECT_FALSE(enclosure) << "Enclosure 1 found but does not exist";
-        enclosure = others->get<musx::dom::others::TextExpressionEnclosure>(25);
+        enclosure = others->get<others::TextExpressionEnclosure>(SCORE_PARTID, 25);
         ASSERT_TRUE(enclosure) << "Enclosure 25 not found but does exist";
         EXPECT_EQ(enclosure->xAdd, -2);
         EXPECT_EQ(enclosure->yAdd, 2);
         EXPECT_EQ(enclosure->xMargin, -9);
         EXPECT_EQ(enclosure->yMargin, 23);
         EXPECT_EQ(enclosure->lineWidth, 128);
-        EXPECT_EQ(enclosure->shape, musx::dom::others::Enclosure::Shape::Triangle);
+        EXPECT_EQ(enclosure->shape, others::Enclosure::Shape::Triangle);
         EXPECT_EQ(enclosure->cornerRadius, 1088);
         EXPECT_FALSE(enclosure->equalAspect);
         EXPECT_TRUE(enclosure->fixedSize);
@@ -90,16 +91,16 @@ TEST(EnclosureTest, TextRepeatEnclosure)
         auto doc = musx::factory::DocumentFactory::create<musx::xml::tinyxml2::Document>(xml);
         auto others = doc->getOthers();
         ASSERT_TRUE(others);
-        auto enclosure = others->get<musx::dom::others::TextRepeatEnclosure>(1);
+        auto enclosure = others->get<others::TextRepeatEnclosure>(SCORE_PARTID, 1);
         EXPECT_FALSE(enclosure) << "Enclosure 1 found but does not exists";
-        enclosure = others->get<musx::dom::others::TextRepeatEnclosure>(12);
+        enclosure = others->get<others::TextRepeatEnclosure>(SCORE_PARTID, 12);
         ASSERT_TRUE(enclosure) << "Enclosure 12 not found but does exist";
         EXPECT_EQ(enclosure->xAdd, 0);
         EXPECT_EQ(enclosure->yAdd, 0);
         EXPECT_EQ(enclosure->xMargin, 9);
         EXPECT_EQ(enclosure->yMargin, 9);
         EXPECT_EQ(enclosure->lineWidth, 256);
-        EXPECT_EQ(enclosure->shape, musx::dom::others::Enclosure::Shape::Rectangle);
+        EXPECT_EQ(enclosure->shape, others::Enclosure::Shape::Rectangle);
         EXPECT_EQ(enclosure->cornerRadius, 0);
         EXPECT_FALSE(enclosure->fixedSize);
         EXPECT_TRUE(enclosure->equalAspect);
@@ -143,8 +144,8 @@ TEST(EnclosureTest, EnumDefault)
         auto doc = musx::factory::DocumentFactory::create<musx::xml::tinyxml2::Document>(xml);
         auto others = doc->getOthers();
         ASSERT_TRUE(others);
-        auto enclosure = others->get<musx::dom::others::TextRepeatEnclosure>(12);
+        auto enclosure = others->get<others::TextRepeatEnclosure>(SCORE_PARTID, 12);
         ASSERT_TRUE(enclosure) << "Enclosure 12 not found but does exist";
-        EXPECT_EQ(enclosure->shape, musx::dom::others::Enclosure::Shape::NoEnclosure);
+        EXPECT_EQ(enclosure->shape, others::Enclosure::Shape::NoEnclosure);
     }
 }

--- a/tests/others/expression.cpp
+++ b/tests/others/expression.cpp
@@ -24,6 +24,8 @@
 #include "musx/musx.h"
 #include "test_utils.h"
 
+using namespace musx::dom;
+
 TEST(TextExpressionDefTest, ValidExpression)
 {
     constexpr static musxtest::string_view xml = R"xml(
@@ -56,25 +58,25 @@ TEST(TextExpressionDefTest, ValidExpression)
     auto others = doc->getOthers();
     ASSERT_TRUE(others) << "Others node not found in XML";
 
-    auto expression = others->get<musx::dom::others::TextExpressionDef>(1);
+    auto expression = others->get<others::TextExpressionDef>(SCORE_PARTID, 1);
     EXPECT_FALSE(expression) << "TextExpressionDef with cmper=1 found but does not exist";
-    expression = others->get<musx::dom::others::TextExpressionDef>(3);
+    expression = others->get<others::TextExpressionDef>(SCORE_PARTID, 3);
     ASSERT_TRUE(expression) << "TextExpressionDef with cmper=3 not found but does exist";
 
     // Check every property
     EXPECT_EQ(expression->textIdKey, 4);  // From XML
     EXPECT_EQ(expression->categoryId, 1);  // From XML
-    EXPECT_EQ(expression->rehearsalMarkStyle, musx::dom::others::RehearsalMarkStyle::MeasureNumber);  // From XML
+    EXPECT_EQ(expression->rehearsalMarkStyle, others::RehearsalMarkStyle::MeasureNumber);  // From XML
     EXPECT_EQ(expression->value, 101);  // From XML
     EXPECT_EQ(expression->playPass, 2);  // From XML
     EXPECT_TRUE(expression->hideMeasureNum);  // From XML
     EXPECT_TRUE(expression->useAuxData);  // From XML
     EXPECT_FALSE(expression->hasEnclosure);  // Default
     EXPECT_FALSE(expression->breakMmRest);  // Default
-    EXPECT_EQ(expression->playbackType, musx::dom::others::PlaybackType::MidiController);  // From XML
-    EXPECT_EQ(expression->horzMeasExprAlign, musx::dom::others::HorizontalMeasExprAlign::LeftOfPrimaryNotehead);  // From XML
-    EXPECT_EQ(expression->horzExprJustification, musx::dom::others::HorizontalExprJustification::Right);  // From XML
-    EXPECT_EQ(expression->vertMeasExprAlign, musx::dom::others::VerticalMeasExprAlign::AboveStaff);  // Default
+    EXPECT_EQ(expression->playbackType, others::PlaybackType::MidiController);  // From XML
+    EXPECT_EQ(expression->horzMeasExprAlign, others::HorizontalMeasExprAlign::LeftOfPrimaryNotehead);  // From XML
+    EXPECT_EQ(expression->horzExprJustification, others::HorizontalExprJustification::Right);  // From XML
+    EXPECT_EQ(expression->vertMeasExprAlign, others::VerticalMeasExprAlign::AboveStaff);  // Default
     EXPECT_EQ(expression->measXAdjust, 0);  // Default
     EXPECT_EQ(expression->yAdjustEntry, -54);  // From XML
     EXPECT_EQ(expression->yAdjustBaseline, 0);  // Default
@@ -83,7 +85,7 @@ TEST(TextExpressionDefTest, ValidExpression)
     EXPECT_EQ(expression->description, "fortissimo (velocity = 101)");  // From XML
 
     // Check marking cat
-    auto cat = others->get<musx::dom::others::MarkingCategory>(expression->categoryId);
+    auto cat = others->get<others::MarkingCategory>(SCORE_PARTID, expression->categoryId);
     ASSERT_TRUE(cat);
     auto it = cat->textExpressions.find(expression->getCmper());
     ASSERT_NE(it, cat->textExpressions.end());
@@ -154,11 +156,11 @@ TEST(MarkingCategoryTest, ValidMarkingCategory)
     ASSERT_TRUE(others) << "Others node not found in XML";
 
     // Get MarkingCategory with cmper=10
-    auto markingCategory = others->get<musx::dom::others::MarkingCategory>(10);
+    auto markingCategory = others->get<others::MarkingCategory>(SCORE_PARTID, 10);
     ASSERT_TRUE(markingCategory) << "MarkingCategory with cmper=10 not found but does exist";
 
     // Check every property of MarkingCategory
-    EXPECT_EQ(markingCategory->categoryType, musx::dom::others::MarkingCategory::CategoryType::Dynamics);  // From XML
+    EXPECT_EQ(markingCategory->categoryType, others::MarkingCategory::CategoryType::Dynamics);  // From XML
 
     // textFont properties
     ASSERT_TRUE(markingCategory->textFont) << "TextFont is missing but exists in XML";
@@ -186,10 +188,10 @@ TEST(MarkingCategoryTest, ValidMarkingCategory)
     EXPECT_EQ(markingCategory->numberFont, nullptr) << "NumberFont should be nullptr but is not";
 
     // Other properties
-    EXPECT_EQ(markingCategory->justification, musx::dom::others::HorizontalExprJustification::Right);  // From XML
-    EXPECT_EQ(markingCategory->horzAlign, musx::dom::others::HorizontalMeasExprAlign::LeftOfAllNoteheads);  // From XML
+    EXPECT_EQ(markingCategory->justification, others::HorizontalExprJustification::Right);  // From XML
+    EXPECT_EQ(markingCategory->horzAlign, others::HorizontalMeasExprAlign::LeftOfAllNoteheads);  // From XML
     EXPECT_EQ(markingCategory->horzOffset, 12);  // From XML
-    EXPECT_EQ(markingCategory->vertAlign, musx::dom::others::VerticalMeasExprAlign::AboveStaffOrEntry);  // From XML
+    EXPECT_EQ(markingCategory->vertAlign, others::VerticalMeasExprAlign::AboveStaffOrEntry);  // From XML
     EXPECT_EQ(markingCategory->vertOffsetEntry, 36);  // From XML
     EXPECT_EQ(markingCategory->vertOffsetBaseline, 36);  // From XML
 
@@ -205,7 +207,7 @@ TEST(MarkingCategoryTest, ValidMarkingCategory)
     EXPECT_EQ(markingCategory->staffList, 1);  // From XML
 
     // Get MarkingCategoryName with cmper=10
-    auto markingCategoryName = others->get<musx::dom::others::MarkingCategoryName>(10);
+    auto markingCategoryName = others->get<others::MarkingCategoryName>(SCORE_PARTID, 10);
     ASSERT_TRUE(markingCategoryName) << "MarkingCategoryName with cmper=10 not found but does exist";
     EXPECT_EQ(markingCategoryName->name, "Vocal Dynamics");
 
@@ -238,14 +240,14 @@ TEST(TextExpressionDefTest, EnumDefaults)
     auto others = doc->getOthers();
     ASSERT_TRUE(others) << "Others node not found in XML";
 
-    auto expression = others->get<musx::dom::others::TextExpressionDef>(3);
+    auto expression = others->get<others::TextExpressionDef>(SCORE_PARTID, 3);
     ASSERT_TRUE(expression) << "TextExpressionDef with cmper=3 not found but does exist";
 
-    EXPECT_EQ(expression->rehearsalMarkStyle, musx::dom::others::RehearsalMarkStyle::None);
-    EXPECT_EQ(expression->playbackType, musx::dom::others::PlaybackType::None);
-    EXPECT_EQ(expression->horzMeasExprAlign, musx::dom::others::HorizontalMeasExprAlign::LeftBarline);
-    EXPECT_EQ(expression->horzExprJustification, musx::dom::others::HorizontalExprJustification::Left);
-    EXPECT_EQ(expression->vertMeasExprAlign, musx::dom::others::VerticalMeasExprAlign::AboveStaff);
+    EXPECT_EQ(expression->rehearsalMarkStyle, others::RehearsalMarkStyle::None);
+    EXPECT_EQ(expression->playbackType, others::PlaybackType::None);
+    EXPECT_EQ(expression->horzMeasExprAlign, others::HorizontalMeasExprAlign::LeftBarline);
+    EXPECT_EQ(expression->horzExprJustification, others::HorizontalExprJustification::Left);
+    EXPECT_EQ(expression->vertMeasExprAlign, others::VerticalMeasExprAlign::AboveStaff);
 }
 
 TEST(MarkingCategoryTest, MissingCategoryType)

--- a/tests/others/fonts.cpp
+++ b/tests/others/fonts.cpp
@@ -24,6 +24,8 @@
 #include "musx/musx.h"
 #include "test_utils.h"
 
+using namespace musx::dom;
+
 constexpr static musxtest::string_view fontProperties = R"xml(
 <?xml version="1.0" encoding="UTF-8"?>
 <finale>
@@ -64,13 +66,13 @@ TEST(FontTest, FontInfoPropertiesTest)
     auto doc = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(fontProperties);
     auto options = doc->getOptions();
     ASSERT_TRUE(options);
-    auto fontOptions = options->get<musx::dom::options::FontOptions>();
+    auto fontOptions = options->get<options::FontOptions>();
     ASSERT_TRUE(fontOptions);
     EXPECT_THROW(
-        fontOptions->getFontInfo(musx::dom::options::FontOptions::FontType::AbbrvStaffNames),
+        fontOptions->getFontInfo(options::FontOptions::FontType::AbbrvStaffNames),
         std::invalid_argument
     );
-    auto fontInfo = fontOptions->getFontInfo(musx::dom::options::FontOptions::FontType::Ending);
+    auto fontInfo = fontOptions->getFontInfo(options::FontOptions::FontType::Ending);
     ASSERT_TRUE(fontInfo);
     EXPECT_EQ(fontInfo->fontId, 1);
     EXPECT_EQ(fontInfo->fontSize, 12);
@@ -88,7 +90,7 @@ TEST(FontTest, FontDefinitionProperties)
     auto doc = musx::factory::DocumentFactory::create<musx::xml::tinyxml2::Document>(fontProperties);
     auto others = doc->getOthers();
     ASSERT_TRUE(others);
-    auto fontDef = others->get<musx::dom::others::FontDefinition>(1);
+    auto fontDef = others->get<others::FontDefinition>(SCORE_PARTID, 1);
     ASSERT_TRUE(fontDef);
     EXPECT_EQ(fontDef->charsetBank, "Mac");
     EXPECT_EQ(fontDef->charsetVal, 1);
@@ -100,7 +102,7 @@ TEST(FontTest, FontDefinitionProperties)
 TEST(FontTest, FontInfoNoName)
 {
     auto doc = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(fontProperties);
-    auto fontInfo = musx::dom::options::FontOptions::getFontInfo(doc, musx::dom::options::FontOptions::FontType::Music);
+    auto fontInfo = options::FontOptions::getFontInfo(doc, options::FontOptions::FontType::Music);
     ASSERT_TRUE(fontInfo);
     EXPECT_EQ(fontInfo->fontId, 13);
     EXPECT_EQ(fontInfo->fontSize, 24);

--- a/tests/others/frame.cpp
+++ b/tests/others/frame.cpp
@@ -52,19 +52,19 @@ TEST(FrameTest, PopulateFields)
     auto others = doc->getOthers();
     ASSERT_TRUE(others);
     
-    auto frame = others->get<others::Frame>(1);
+    auto frame = others->get<others::Frame>(SCORE_PARTID, 1);
     ASSERT_TRUE(frame) << "Frame with cmper 1 not found";
     
     EXPECT_EQ(frame->startEntry, 1);
     EXPECT_EQ(frame->endEntry, 2);
 
-    frame = others->get<others::Frame>(2);
+    frame = others->get<others::Frame>(SCORE_PARTID, 2);
     ASSERT_TRUE(frame) << "Frame with cmper 2 not found";
 
     EXPECT_EQ(frame->startEntry, 2140);
     EXPECT_EQ(frame->endEntry, 2142);
 
-    frame = others->get<others::Frame>(3);
+    frame = others->get<others::Frame>(SCORE_PARTID, 3);
     ASSERT_TRUE(frame) << "Frame with cmper 3 not found";
 
     EXPECT_EQ(frame->startEntry, 2144);

--- a/tests/others/instrument_used.cpp
+++ b/tests/others/instrument_used.cpp
@@ -66,7 +66,7 @@ TEST(InstrumentUsedTest, PopulateFields)
 
     // Test InstrumentUsed with cmper=1 (system) and inci=0
     {
-        auto instUsed = others->get<others::InstrumentUsed>(1, 0);
+        auto instUsed = others->get<others::InstrumentUsed>(SCORE_PARTID, 1, 0);
         ASSERT_TRUE(instUsed);
 
         EXPECT_EQ(instUsed->staffId, 6);
@@ -81,7 +81,7 @@ TEST(InstrumentUsedTest, PopulateFields)
 
     // Test InstrumentUsed with cmper=1 (system) and inci=1
     {
-        auto instUsed = others->get<others::InstrumentUsed>(1, 1);
+        auto instUsed = others->get<others::InstrumentUsed>(SCORE_PARTID, 1, 1);
         ASSERT_TRUE(instUsed);
 
         EXPECT_EQ(instUsed->staffId, 16);

--- a/tests/others/layer_attributes.cpp
+++ b/tests/others/layer_attributes.cpp
@@ -72,7 +72,7 @@ TEST(LayerAttributesTest, PopulateLayerAttributes)
     // Test LayerAttributes for each cmper value
     for (Cmper i = 0; i < 4; ++i)
     {
-        auto layerAttributes = others->get<musx::dom::others::LayerAttributes>(i);
+        auto layerAttributes = others->get<others::LayerAttributes>(SCORE_PARTID, i);
         ASSERT_TRUE(layerAttributes);
 
         if (i == 0)

--- a/tests/others/measure_number_region.cpp
+++ b/tests/others/measure_number_region.cpp
@@ -121,7 +121,7 @@ TEST(MeasureNumberRegionTest, PropertiesTest)
     auto others = doc->getOthers();
     ASSERT_TRUE(others);
 
-    auto measureNumberRegion = others->get<MeasureNumberRegion>(1);
+    auto measureNumberRegion = others->get<MeasureNumberRegion>(SCORE_PARTID, 1);
     ASSERT_TRUE(measureNumberRegion);
 
     // Test basic region fields

--- a/tests/others/part_definition.cpp
+++ b/tests/others/part_definition.cpp
@@ -24,6 +24,8 @@
 #include "musx/musx.h"
 #include "test_utils.h"
 
+using namespace musx::dom;
+
 constexpr static musxtest::string_view xml = R"xml(
 <?xml version="1.0" encoding="UTF-8"?>
 <finale>
@@ -60,7 +62,7 @@ TEST(PartDefinitionTest, PopulateFields)
     auto others = doc->getOthers();
     ASSERT_TRUE(others);
     
-    auto partDef = others->get<musx::dom::others::PartDefinition>(1);
+    auto partDef = others->get<others::PartDefinition>(SCORE_PARTID, 1);
     ASSERT_TRUE(partDef) << "PartDefinition with cmper 1 not found";
     
     EXPECT_EQ(partDef->nameId, 42);
@@ -78,7 +80,7 @@ TEST(PartDefinitionTest, GetName)
     auto others = doc->getOthers();
     ASSERT_TRUE(others);
     
-    auto partDef = others->get<musx::dom::others::PartDefinition>(1);
+    auto partDef = others->get<others::PartDefinition>(SCORE_PARTID, 1);
     ASSERT_TRUE(partDef) << "PartDefinition with cmper 1 not found";
 
     EXPECT_EQ(partDef->getName(), "Alto Sax in Eb");

--- a/tests/others/part_definition.cpp
+++ b/tests/others/part_definition.cpp
@@ -30,6 +30,85 @@ constexpr static musxtest::string_view xml = R"xml(
 <?xml version="1.0" encoding="UTF-8"?>
 <finale>
   <others>
+    <measNumbRegion cmper="1">
+      <scoreData>
+        <startFont>
+          <fontID>1</fontID>
+          <fontSize>10</fontSize>
+          <efx>
+            <italic/>
+            <absolute/>
+          </efx>
+        </startFont>
+        <multipleFont>
+          <fontID>2</fontID>
+          <fontSize>12</fontSize>
+        </multipleFont>
+        <mmRestFont>
+          <fontID>3</fontID>
+          <fontSize>14</fontSize>
+        </mmRestFont>
+        <startEnclosure>
+          <xMargin>9</xMargin>
+          <yMargin>9</yMargin>
+          <lineWidth>256</lineWidth>
+          <sides>1</sides>
+          <notTall/>
+          <roundCorners/>
+          <cornerRadius>768</cornerRadius>
+        </startEnclosure>
+        <multipleEnclosure>
+          <xMargin>44</xMargin>
+          <yMargin>44</yMargin>
+          <lineWidth>256</lineWidth>
+          <sides>2</sides>
+          <notTall/>
+          <roundCorners/>
+          <cornerRadius>768</cornerRadius>
+        </multipleEnclosure>
+        <startXdisp>1</startXdisp>
+        <startYdisp>-144</startYdisp>
+        <multipleXdisp>3</multipleXdisp>
+        <multipleYdisp>-144</multipleYdisp>
+        <mmRestXdisp>5</mmRestXdisp>
+        <mmRestYdisp>-144</mmRestYdisp>
+        <leftMmBracketChar>91</leftMmBracketChar>
+        <rightMmBracketChar>93</rightMmBracketChar>
+        <startWith>2</startWith>
+        <incidence>1</incidence>
+        <multipleAlign>center</multipleAlign>
+        <mmRestAlign>center</mmRestAlign>
+        <startOfLine/>
+        <multipleOf/>
+        <exceptFirstMeas/>
+        <mmRestRange/>
+        <mmRestRangeForce/>
+        <useStartEncl/>
+        <useMultipleEncl/>
+        <showOnTop/>
+        <showOnBottom/>
+        <excludeOthers/>
+        <breakMmRest/>
+        <multipleJustify>center</multipleJustify>
+        <mmRestJustify>center</mmRestJustify>
+      </scoreData>
+      <startMeas>1</startMeas>
+      <endMeas>1000</endMeas>
+      <startChar>164</startChar>
+      <base>10</base>
+      <offset>2</offset>
+      <prefix>&lt;|</prefix>
+      <suffix>&gt;|</suffix>
+      <countFromOne/>
+      <noZero/>
+      <doubleUp/>
+      <includeHours/>
+      <smpteFrames/>
+      <useScoreInfoForPart/>
+      <region>1</region>
+      <timePrecision>thousandths</timePrecision>
+      <hideScroll/>
+    </measNumbRegion>
     <partDef cmper="1">
       <nameID>42</nameID>
       <partOrder>3</partOrder>
@@ -58,7 +137,7 @@ constexpr static musxtest::string_view xml = R"xml(
 
 TEST(PartDefinitionTest, PopulateFields)
 {
-    auto doc = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(xml);
+    auto doc = musx::factory::DocumentFactory::create<musx::xml::tinyxml2::Document>(xml);
     auto others = doc->getOthers();
     ASSERT_TRUE(others);
     
@@ -84,4 +163,13 @@ TEST(PartDefinitionTest, GetName)
     ASSERT_TRUE(partDef) << "PartDefinition with cmper 1 not found";
 
     EXPECT_EQ(partDef->getName(), "Alto Sax in Eb");
+}
+
+TEST(PartDefinitionTest, GetArrayForScore)
+{
+    auto doc = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(xml);
+    auto others = doc->getOthers();
+    ASSERT_TRUE(others);
+
+    EXPECT_EQ(others->getArray<others::MeasureNumberRegion>(1).size(), 1) << "getArray should return the score's list, since meas numbs always linked";
 }

--- a/tests/others/part_globals.cpp
+++ b/tests/others/part_globals.cpp
@@ -48,7 +48,7 @@ TEST(PartGlobalsTest, PartGlobalsPropertiesTest)
     auto doc = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(partGlobalsXml);
     ASSERT_TRUE(doc);
 
-    auto partGlobals = doc->getOthers()->getEffectiveForPart<musx::dom::others::PartGlobals>(27, MUSX_GLOBALS_CMPER);
+    auto partGlobals = doc->getOthers()->get<others::PartGlobals>(27, MUSX_GLOBALS_CMPER);
     ASSERT_TRUE(partGlobals);
 
     EXPECT_FALSE(partGlobals->showTransposed);
@@ -56,7 +56,7 @@ TEST(PartGlobalsTest, PartGlobalsPropertiesTest)
     EXPECT_EQ(partGlobals->studioViewIUlist, 65400);
     EXPECT_EQ(partGlobals->specialPartExtractionIUList, 0);
 
-    auto partGlobalsForScore = doc->getOthers()->getEffectiveForPart<musx::dom::others::PartGlobals>(0, MUSX_GLOBALS_CMPER);
+    auto partGlobalsForScore = doc->getOthers()->get<others::PartGlobals>(SCORE_PARTID, MUSX_GLOBALS_CMPER);
     ASSERT_TRUE(partGlobalsForScore);
 
     EXPECT_TRUE(partGlobalsForScore->showTransposed);
@@ -65,7 +65,7 @@ TEST(PartGlobalsTest, PartGlobalsPropertiesTest)
     EXPECT_EQ(partGlobalsForScore->specialPartExtractionIUList, 65528);
 
     // This should return the score value
-    auto partGlobalsForNonexistent = doc->getOthers()->getEffectiveForPart<musx::dom::others::PartGlobals>(1, MUSX_GLOBALS_CMPER);
+    auto partGlobalsForNonexistent = doc->getOthers()->get<others::PartGlobals>(1, MUSX_GLOBALS_CMPER);
     ASSERT_TRUE(partGlobalsForNonexistent);
 
     EXPECT_TRUE(partGlobalsForNonexistent->showTransposed);

--- a/tests/others/staff.cpp
+++ b/tests/others/staff.cpp
@@ -24,6 +24,8 @@
 #include "musx/musx.h"
 #include "test_utils.h"
 
+using namespace musx::dom;
+
 TEST(StaffTest, PopulateFields)
 {
     constexpr static musxtest::string_view xml = R"xml(
@@ -70,7 +72,7 @@ TEST(StaffTest, PopulateFields)
         auto others = doc->getOthers();
         ASSERT_TRUE(others);
 
-        auto staff1 = others->get<musx::dom::others::Staff>(15);
+        auto staff1 = others->get<others::Staff>(SCORE_PARTID, 15);
         ASSERT_TRUE(staff1) << "Staff with cmper 15 not found";
 
         EXPECT_EQ(staff1->staffLines, 5);
@@ -88,7 +90,7 @@ TEST(StaffTest, PopulateFields)
         EXPECT_EQ(staff1->botRepeatDotOff, -5);
         EXPECT_EQ(staff1->vertTabNumOff, -1024);
 
-        auto staff2 = others->get<musx::dom::others::Staff>(16);
+        auto staff2 = others->get<others::Staff>(SCORE_PARTID, 16);
         ASSERT_TRUE(staff2) << "Staff with cmper 16 not found";
 
         EXPECT_EQ(staff2->staffLines, 5);

--- a/tests/others/text_block.cpp
+++ b/tests/others/text_block.cpp
@@ -24,6 +24,8 @@
 #include "musx/musx.h"
 #include "test_utils.h"
 
+using namespace musx::dom;
+
 TEST(TextBlockTest, PopulateFields)
 {
     constexpr static musxtest::string_view xml = R"xml(
@@ -60,7 +62,7 @@ TEST(TextBlockTest, PopulateFields)
     ASSERT_TRUE(others);
 
     // Test first text block
-    auto textBlock1 = others->get<musx::dom::others::TextBlock>(32);
+    auto textBlock1 = others->get<others::TextBlock>(SCORE_PARTID, 32);
     ASSERT_TRUE(textBlock1) << "TextBlock 32 not found but does exist";
     EXPECT_EQ(textBlock1->textId, 31);
     EXPECT_EQ(textBlock1->lineSpacingPercentage, 100);
@@ -72,10 +74,10 @@ TEST(TextBlockTest, PopulateFields)
     EXPECT_EQ(textBlock1->height, 117);
     EXPECT_TRUE(textBlock1->roundCorners);
     EXPECT_EQ(textBlock1->cornerRadius, 512);
-    EXPECT_EQ(textBlock1->textType, musx::dom::others::TextBlock::TextType::Block);
+    EXPECT_EQ(textBlock1->textType, others::TextBlock::TextType::Block);
 
     // Test second text block
-    auto textBlock2 = others->get<musx::dom::others::TextBlock>(33);
+    auto textBlock2 = others->get<others::TextBlock>(SCORE_PARTID, 33);
     ASSERT_TRUE(textBlock2) << "TextBlock 33 not found but does exist";
     EXPECT_EQ(textBlock2->textId, 221);
     EXPECT_EQ(textBlock2->lineSpacingPercentage, 100);
@@ -87,5 +89,5 @@ TEST(TextBlockTest, PopulateFields)
     EXPECT_EQ(textBlock2->height, 0);
     EXPECT_FALSE(textBlock2->roundCorners);
     EXPECT_EQ(textBlock2->cornerRadius, 0);
-    EXPECT_EQ(textBlock2->textType, musx::dom::others::TextBlock::TextType::Expression);
+    EXPECT_EQ(textBlock2->textType, others::TextBlock::TextType::Expression);
 }

--- a/tests/pool.cpp
+++ b/tests/pool.cpp
@@ -24,6 +24,8 @@
 #include "musx/musx.h"
 #include "test_utils.h"
 
+using namespace musx::dom;
+
 constexpr static musxtest::string_view xml = R"xml(
 <?xml version="1.0" encoding="UTF-8"?>
 <finale>
@@ -212,15 +214,17 @@ constexpr static musxtest::string_view xml = R"xml(
 </finale>
     )xml";
 
+using namespace musx::dom;
+
 TEST(PoolTest, Scalar)
 {
     auto doc = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(xml);
     auto others = doc->getOthers();
     ASSERT_TRUE(others);
-    EXPECT_TRUE(others->get<musx::dom::others::TextExpressionDef>(3));
-    EXPECT_FALSE(others->get<musx::dom::others::TextExpressionDef>(4));
-    EXPECT_TRUE(others->get<musx::dom::others::MarkingCategory>(3));
-    EXPECT_FALSE(others->get<musx::dom::others::MarkingCategory>(8));
+    EXPECT_TRUE(others->get<others::TextExpressionDef>(SCORE_PARTID, 3));
+    EXPECT_FALSE(others->get<others::TextExpressionDef>(SCORE_PARTID, 4));
+    EXPECT_TRUE(others->get<others::MarkingCategory>(SCORE_PARTID, 3));
+    EXPECT_FALSE(others->get<others::MarkingCategory>(SCORE_PARTID, 8));
 }
 
 TEST(PoolTest, Vector)
@@ -228,12 +232,12 @@ TEST(PoolTest, Vector)
     auto doc = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(xml);
     auto others = doc->getOthers();
     ASSERT_TRUE(others);
-    EXPECT_EQ(others->getArray<musx::dom::others::MarkingCategory>().size(), 7);
-    EXPECT_EQ(others->getArray<musx::dom::others::MarkingCategory>(6).size(), 1);
-    EXPECT_EQ(others->getArray<musx::dom::others::MarkingCategory>(5)[0]->categoryType, musx::dom::others::MarkingCategory::CategoryType::TechniqueText);
-    EXPECT_EQ(others->getArray<musx::dom::others::MarkingCategory>(8).size(), 0);
-    EXPECT_EQ(others->getArray<musx::dom::others::TextExpressionDef>().size(), 3);
-    EXPECT_EQ(others->getArray<musx::dom::others::TextExpressionDef>(2).size(), 1);
-    EXPECT_EQ(others->getArray<musx::dom::others::TextExpressionDef>(1)[0]->description, "fortissississimo (velocity = 127)");
-    EXPECT_EQ(others->getArray<musx::dom::others::TextExpressionDef>(4).size(), 0);
+    EXPECT_EQ(others->getArray<others::MarkingCategory>(SCORE_PARTID).size(), 7);
+    EXPECT_EQ(others->getArray<others::MarkingCategory>(SCORE_PARTID, 6).size(), 1);
+    EXPECT_EQ(others->getArray<others::MarkingCategory>(SCORE_PARTID, 5)[0]->categoryType, others::MarkingCategory::CategoryType::TechniqueText);
+    EXPECT_EQ(others->getArray<others::MarkingCategory>(SCORE_PARTID, 8).size(), 0);
+    EXPECT_EQ(others->getArray<others::TextExpressionDef>(SCORE_PARTID).size(), 3);
+    EXPECT_EQ(others->getArray<others::TextExpressionDef>(SCORE_PARTID, 2).size(), 1);
+    EXPECT_EQ(others->getArray<others::TextExpressionDef>(SCORE_PARTID, 1)[0]->description, "fortissississimo (velocity = 127)");
+    EXPECT_EQ(others->getArray<others::TextExpressionDef>(SCORE_PARTID, 4).size(), 0);
 }


### PR DESCRIPTION
- others and details now require `partId` for `get` and `getArray`.
- callers do not need to know whether classes are score-only, partially shared, or fully unlinked. These versions of `get` and `getArray` return the correct values for that part or score.
- `getArray` is disallowed for partially shared classes, at least until there is a requirement to support it.