### PR TITLE
Various integrity issues

### DIFF
--- a/src/musx/dom/ObjectPool.h
+++ b/src/musx/dom/ObjectPool.h
@@ -110,6 +110,14 @@ public:
      */
     void add(const ObjectKey& key, ObjectPtr object)
     {
+        if (key.inci.has_value()) {
+            ObjectKey noInciKey = key;
+            noInciKey.inci = std::nullopt;
+            auto currentIncis = getArray<ObjectBaseType>(noInciKey);
+            if (key.inci.value() != currentIncis.size()) {
+                MUSX_INTEGRITY_ERROR("Node " + key.nodeString() + " has inci " + std::to_string(key.inci.value()) + " that is out of sequence.");
+            }
+        }
         m_pool.emplace(key, object);
         auto it = m_shareMode.find(key.nodeId);
         if (it == m_shareMode.end()) {

--- a/src/musx/dom/Options.h
+++ b/src/musx/dom/Options.h
@@ -913,7 +913,7 @@ public:
     Evpu shortHairpinOpeningWidth{};         ///< "Short Hairpin Opening Width"
     Evpu crescHeight{};                      ///< "Crescendo Height"
     Evpu maximumShortHairpinLength{};       ///< "Maximum Short Hairpin Length"
-    Efix crescLineWidth{};                  ///< "Crescendo Line Width"
+    Efix crescLineWidth{};                  ///< "Crescendo/Decrescendo Line Width"
     Evpu hookLength{};                       ///< "Hook Length"
     Efix smartLineWidth{};                  ///< "Smart Line Width"
     bool showOctavaAsText{};                   ///< "Show Octava As Text"

--- a/src/musx/factory/FieldPopulatorsOthers.cpp
+++ b/src/musx/factory/FieldPopulatorsOthers.cpp
@@ -53,6 +53,8 @@ MUSX_XML_ENUM_MAPPING(MeasureNumberRegion::TimePrecision, {
 
 MUSX_XML_ENUM_MAPPING(Measure::PositioningType, {
     // {"manual", Measure::PositioningType::Manual}, // This is the default and is not known to occur in the XML.
+    {"timesig", Measure::PositioningType::TimeSignature},
+    {"beatchart", Measure::PositioningType::BeatChart},
     {"timesigPlusPos", Measure::PositioningType::TimeSigPlusPositioning},
     {"beatchartPlusPos", Measure::PositioningType::BeatChartPlusPositioning},
 });
@@ -191,11 +193,12 @@ MUSX_XML_ELEMENT_ARRAY(FontDefinition, {
     {"pitch", [](const XmlElementPtr& e, const std::shared_ptr<FontDefinition>& i) { i->pitch = e->getTextAs<int>(); }},
     {"family", [](const XmlElementPtr& e, const std::shared_ptr<FontDefinition>& i) { i->family = e->getTextAs<int>(); }},
     {"name", [](const XmlElementPtr& e, const std::shared_ptr<FontDefinition>& i) { i->name = e->getText(); }},
-    });
+});
 
 MUSX_XML_ELEMENT_ARRAY(Frame, {
     {"startEntry", [](const XmlElementPtr& e, const std::shared_ptr<Frame>& i) { i->startEntry = e->getTextAs<EntryNumber>(); }},
     {"endEntry", [](const XmlElementPtr& e, const std::shared_ptr<Frame>& i) { i->endEntry = e->getTextAs<EntryNumber>(); }},
+    {"startTime", [](const XmlElementPtr& e, const std::shared_ptr<Frame>& i) { i->startTime = e->getTextAs<Edu>(); }},
 });
 
 MUSX_XML_ELEMENT_ARRAY(MusicRange, {


### PR DESCRIPTION
- Discovered that `Frame` can have multiple incis, so deal with that case.
- Add inci sequencing integrity check
- Add missing xml nodes flagged in testing.
